### PR TITLE
Change image tags for Switch and Wii U

### DIFF
--- a/.github/workflows/generate-builds.yml
+++ b/.github/workflows/generate-builds.yml
@@ -191,7 +191,7 @@ jobs:
     needs: generate-soh-otr
     runs-on: ${{ (vars.LINUX_RUNNER && fromJSON(vars.LINUX_RUNNER)) || 'ubuntu-latest' }}
     container:
-      image: devkitpro/devkita64:latest
+      image: devkitpro/devkita64:20230929
     steps:
     - name: Install dependencies
       run: |
@@ -230,7 +230,7 @@ jobs:
     needs: generate-soh-otr
     runs-on: ${{ (vars.LINUX_RUNNER && fromJSON(vars.LINUX_RUNNER)) || 'ubuntu-latest' }}
     container:
-      image: devkitpro/devkitppc:20230110
+      image: devkitpro/devkitppc:20230929
     steps:
     - name: Install dependencies
       if: ${{ !vars.LINUX_RUNNER }}


### PR DESCRIPTION
Updated Wii U tag to newer release tag for several incoming PRs that need newer release, and changed Switch to release tag ref instead of :latest, to prevent surprises in new builds.