### PR TITLE
handle temp B on saving outside of kaleido

### DIFF
--- a/soh/src/code/z_play.c
+++ b/soh/src/code/z_play.c
@@ -2329,7 +2329,27 @@ void Play_PerformSave(PlayState* play) {
     if (play != NULL && gSaveContext.fileNum != 0xFF) {
         Play_SaveSceneFlags(play);
         gSaveContext.savedSceneNum = play->sceneNum;
+
+        // Track values from temp B
+        uint8_t prevB = gSaveContext.equips.buttonItems[0];
+        uint8_t prevStatus = gSaveContext.buttonStatus[0];
+
+        // Replicate the B button restore from minigames/epona that kaleido does
+        if (gSaveContext.equips.buttonItems[0] == ITEM_SLINGSHOT ||
+            gSaveContext.equips.buttonItems[0] == ITEM_BOW ||
+            gSaveContext.equips.buttonItems[0] == ITEM_BOMBCHU ||
+            gSaveContext.equips.buttonItems[0] == ITEM_FISHING_POLE ||
+            (gSaveContext.equips.buttonItems[0] == ITEM_NONE && !Flags_GetInfTable(INFTABLE_SWORDLESS))) {
+
+            gSaveContext.equips.buttonItems[0] = gSaveContext.buttonStatus[0];
+            Interface_RandoRestoreSwordless();
+        }
+
         Save_SaveFile();
+
+        // Restore temp B values back
+        gSaveContext.equips.buttonItems[0] = prevB;
+        gSaveContext.buttonStatus[0] = prevStatus;
 
         uint8_t triforceHuntCompleted =
             IS_RANDO &&


### PR DESCRIPTION
replicates the temp B restoration that kaleido normally does when pausing, so that autosaves that are triggered when kaleido is not open, we dont accidentally save the wrong B button item

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh.otr.zip](https://nightly.link/Malkierian/Shipwright/actions/artifacts/1047795097.zip)
  - [soh-linux-compatibility.zip](https://nightly.link/Malkierian/Shipwright/actions/artifacts/1047795098.zip)
  - [soh-linux-performance.zip](https://nightly.link/Malkierian/Shipwright/actions/artifacts/1047795099.zip)
  - [soh-mac.zip](https://nightly.link/Malkierian/Shipwright/actions/artifacts/1047795101.zip)
  - [soh-switch.zip](https://nightly.link/Malkierian/Shipwright/actions/artifacts/1047795103.zip)
  - [soh-wiiu.zip](https://nightly.link/Malkierian/Shipwright/actions/artifacts/1047795108.zip)
  - [soh-windows.zip](https://nightly.link/Malkierian/Shipwright/actions/artifacts/1047795110.zip)
<!--- section:artifacts:end -->