### PR TITLE
Fix slider width calculation and allow combobox LabelPosition::None

### DIFF
--- a/soh/soh/Enhancements/randomizer/Plandomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/Plandomizer.cpp
@@ -933,7 +933,7 @@ void PlandomizerDrawOptions() {
         PlandomizerPopulateSeedList();
         static size_t selectedList = 0;
         if (existingSeedList.size() != 0) {
-            UIWidgets2::Combobox("##JsonFiles", &selectedList, existingSeedList, UIWidgets2::ComboboxOptions().Color(THEME_COLOR));
+            UIWidgets2::Combobox("##JsonFiles", &selectedList, existingSeedList, UIWidgets2::ComboboxOptions().Color(THEME_COLOR).LabelPosition(UIWidgets2::LabelPosition::None));
         }
         else {
             ImGui::Text("No Spoiler Logs found.");
@@ -1025,23 +1025,6 @@ void PlandomizerDrawOptions() {
     if (getTabID == TAB_LOCATIONS) {
         if (plandoLogData.size() > 0) {
             UIWidgets2::Combobox("Filter by Area:##AreaFilter", &selectedArea, rcAreaNameMap, UIWidgets2::ComboboxOptions().Color(THEME_COLOR).LabelPosition(UIWidgets2::LabelPosition::Near).ComponentAlignment(UIWidgets2::ComponentAlignment::Right));
-            // if (ImGui::BeginCombo("##AreaFilter", comboLabel)) {
-            //     for (const auto& [area, name] : rcAreaNames) {
-            //         bool isSelected = (selectedArea == area);
-
-            //         const char* displayName = name.c_str();
-            //         if (area == RCAREA_INVALID) {
-            //             displayName = "All";
-            //         }
-            //         if (ImGui::Selectable(displayName, isSelected)) {
-            //             selectedArea = area;
-            //         }
-            //         if (isSelected) {
-            //             ImGui::SetItemDefaultFocus();
-            //         }
-            //     }
-            //     ImGui::EndCombo();
-            // }    
             ImGui::SameLine();
             if (UIWidgets2::Button("Empty All Rewards", UIWidgets2::ButtonOptions().Color(THEME_COLOR).Size(UIWidgets2::Sizes::Inline).Padding(ImVec2(10.f, 6.f)))) {
                 PlandomizerRemoveAllItems();

--- a/soh/soh/Enhancements/randomizer/option.cpp
+++ b/soh/soh/Enhancements/randomizer/option.cpp
@@ -232,7 +232,7 @@ bool Option::RenderCombobox() {
     }
     UIWidgets2::ComboboxOptions widgetOptions = UIWidgets2::ComboboxOptions().Color(THEME_COLOR).Tooltip(description.c_str());
     if (this->GetKey() == RSK_LOGIC_RULES) {
-        widgetOptions = widgetOptions.LabelPosition(UIWidgets2::LabelPosition::Near).ComponentAlignment(UIWidgets2::ComponentAlignment::Right);
+        widgetOptions = widgetOptions.LabelPosition(UIWidgets2::LabelPosition::None).ComponentAlignment(UIWidgets2::ComponentAlignment::Right);
     }
     widgetOptions.disabled = disabled;
     if(UIWidgets2::Combobox(name.c_str(), &selected, options, widgetOptions)) {

--- a/soh/soh/SohGui/UIWidgets2.cpp
+++ b/soh/soh/SohGui/UIWidgets2.cpp
@@ -508,6 +508,9 @@ bool SliderInt(const char* label, int32_t* value, const IntSliderOptions& option
     ImGui::BeginDisabled(options.disabled);
     PushStyleSlider(options.color);
     float width = (options.size == ImVec2(0,0)) ? ImGui::GetContentRegionAvail().x : options.size.x;
+    if (options.labelPosition == LabelPosition::Near || options.labelPosition == LabelPosition::Far) {
+        width = width - (ImGui::CalcTextSize(label).x + ImGui::GetStyle().FramePadding.x);
+    }
     ImGui::AlignTextToFramePadding();
     if (options.alignment == ComponentAlignment::Right) {
         ImGui::Text(label, *value);
@@ -648,6 +651,9 @@ bool SliderFloat(const char* label, float* value, const FloatSliderOptions& opti
     PushStyleSlider(options.color);
     float labelSpacing = ImGui::CalcTextSize(label).x + ImGui::GetStyle().ItemSpacing.x;
     float width = (options.size == ImVec2(0, 0)) ? ImGui::GetContentRegionAvail().x : options.size.x;
+    if (options.labelPosition == LabelPosition::Near || options.labelPosition == LabelPosition::Far) {
+        width = width - (ImGui::CalcTextSize(label).x + ImGui::GetStyle().FramePadding.x);
+    }
     ImGui::AlignTextToFramePadding();
     if (options.alignment == ComponentAlignment::Right) {
         ImGui::Text("%s", label);

--- a/soh/soh/SohGui/UIWidgets2.hpp
+++ b/soh/soh/SohGui/UIWidgets2.hpp
@@ -620,18 +620,18 @@ namespace UIWidgets2 {
         ImGui::AlignTextToFramePadding();
         if (options.labelPosition != LabelPosition::None) {
             if (options.alignment == ComponentAlignment::Right) {
-                ImGui::Text("%s", label);
+                ImGui::Text(label);
                 if (options.labelPosition == LabelPosition::Above) {
                     ImGui::NewLine();
                     ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
                 } else if (options.labelPosition == LabelPosition::Near) {
                     ImGui::SameLine();
-                } else if (options.labelPosition == LabelPosition::Far || options.labelPosition == LabelPosition::None) {
+                } else if (options.labelPosition == LabelPosition::Far) {
                     ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
                 }
             } else if (options.alignment == ComponentAlignment::Left) {
                 if (options.labelPosition == LabelPosition::Above) {
-                    ImGui::Text("%s", label);
+                    ImGui::Text(label);
                 }
             }
         }
@@ -651,14 +651,16 @@ namespace UIWidgets2 {
             ImGui::EndCombo();
         }
 
-        if (options.alignment == ComponentAlignment::Left) {
-            if (options.labelPosition == LabelPosition::Near) {
-                ImGui::SameLine();
-                ImGui::Text("%s", label);
-            } else if (options.labelPosition == LabelPosition::Far || options.labelPosition == LabelPosition::None) {
-                float width = ImGui::CalcTextSize(comboMap.at(*value)).x + ImGui::GetStyle().FramePadding.x * 2;
-                ImGui::SameLine(ImGui::GetContentRegionAvail().x - width);
-                ImGui::Text("%s", label);
+        if (options.labelPosition != LabelPosition::None) {
+            if (options.alignment == ComponentAlignment::Left) {
+                if (options.labelPosition == LabelPosition::Near) {
+                    ImGui::SameLine();
+                    ImGui::Text("%s", label);
+                } else if (options.labelPosition == LabelPosition::Far) {
+                    float width = ImGui::CalcTextSize(comboMap.at(*value)).x + ImGui::GetStyle().FramePadding.x * 2;
+                    ImGui::SameLine(ImGui::GetContentRegionAvail().x - width);
+                    ImGui::Text("%s", label);
+                }
             }
         }
         PopStyleCombobox();
@@ -704,7 +706,7 @@ namespace UIWidgets2 {
                     ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
                 } else if (options.labelPosition == LabelPosition::Near) {
                     ImGui::SameLine();
-                } else if (options.labelPosition == LabelPosition::Far || options.labelPosition == LabelPosition::None) {
+                } else if (options.labelPosition == LabelPosition::Far) {
                     ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
                 }
             } else if (options.alignment == ComponentAlignment::Left) {
@@ -730,14 +732,16 @@ namespace UIWidgets2 {
             ImGui::EndCombo();
         }
 
-        if (options.alignment == ComponentAlignment::Left) {
-            if (options.labelPosition == LabelPosition::Near) {
-                ImGui::SameLine();
-                ImGui::Text("%s", label);
-            } else if (options.labelPosition == LabelPosition::Far || options.labelPosition == LabelPosition::None) {
-                float width = ImGui::CalcTextSize(comboVector.at(*value)).x + ImGui::GetStyle().FramePadding.x * 2;
-                ImGui::SameLine(ImGui::GetContentRegionAvail().x - width);
-                ImGui::Text("%s", label);
+        if (options.labelPosition != LabelPosition::None) {
+            if (options.alignment == ComponentAlignment::Left) {
+                if (options.labelPosition == LabelPosition::Near) {
+                    ImGui::SameLine();
+                    ImGui::Text("%s", label);
+                } else if (options.labelPosition == LabelPosition::Far) {
+                    float width = ImGui::CalcTextSize(comboVector.at(*value)).x + ImGui::GetStyle().FramePadding.x * 2;
+                    ImGui::SameLine(ImGui::GetContentRegionAvail().x - width);
+                    ImGui::Text("%s", label);
+                }
             }
         }
 
@@ -784,7 +788,7 @@ namespace UIWidgets2 {
                     ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
                 } else if (options.labelPosition == LabelPosition::Near) {
                     ImGui::SameLine();
-                } else if (options.labelPosition == LabelPosition::Far || options.labelPosition == LabelPosition::None) {
+                } else if (options.labelPosition == LabelPosition::Far) {
                     ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
                 }
             } else if (options.alignment == ComponentAlignment::Left) {
@@ -810,14 +814,16 @@ namespace UIWidgets2 {
             ImGui::EndCombo();
         }
 
-        if (options.alignment == ComponentAlignment::Left) {
-            if (options.labelPosition == LabelPosition::Near) {
-                ImGui::SameLine();
-                ImGui::Text("%s", label);
-            } else if (options.labelPosition == LabelPosition::Far || options.labelPosition == LabelPosition::None) {
-                float width = ImGui::CalcTextSize(comboVector.at(*value).c_str()).x + ImGui::GetStyle().FramePadding.x * 2;
-                ImGui::SameLine(ImGui::GetContentRegionAvail().x - width);
-                ImGui::Text("%s", label);
+        if (options.labelPosition != LabelPosition::None) {
+            if (options.alignment == ComponentAlignment::Left) {
+                if (options.labelPosition == LabelPosition::Near) {
+                    ImGui::SameLine();
+                    ImGui::Text("%s", label);
+                } else if (options.labelPosition == LabelPosition::Far) {
+                    float width = ImGui::CalcTextSize(comboVector.at(*value).c_str()).x + ImGui::GetStyle().FramePadding.x * 2;
+                    ImGui::SameLine(ImGui::GetContentRegionAvail().x - width);
+                    ImGui::Text("%s", label);
+                }
             }
         }
 
@@ -867,7 +873,7 @@ namespace UIWidgets2 {
                     ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
                 } else if (options.labelPosition == LabelPosition::Near) {
                     ImGui::SameLine();
-                } else if (options.labelPosition == LabelPosition::Far || options.labelPosition == LabelPosition::None) {
+                } else if (options.labelPosition == LabelPosition::Far) {
                     ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
                 }
             } else if (options.alignment == ComponentAlignment::Left) {
@@ -893,17 +899,18 @@ namespace UIWidgets2 {
             ImGui::EndCombo();
         }
 
-        if (options.alignment == ComponentAlignment::Left) {
-            if (options.labelPosition == LabelPosition::Near) {
-                ImGui::SameLine();
-                ImGui::Text("%s", label);
-            } else if (options.labelPosition == LabelPosition::Far || options.labelPosition == LabelPosition::None) {
-                float width = ImGui::CalcTextSize(comboArray[*value]).x + ImGui::GetStyle().FramePadding.x * 2;
-                ImGui::SameLine(ImGui::GetContentRegionAvail().x - width);
-                ImGui::Text("%s", label);
+        if (options.labelPosition != LabelPosition::None) {
+            if (options.alignment == ComponentAlignment::Left) {
+                if (options.labelPosition == LabelPosition::Near) {
+                    ImGui::SameLine();
+                    ImGui::Text("%s", label);
+                } else if (options.labelPosition == LabelPosition::Far) {
+                    float width = ImGui::CalcTextSize(comboArray[*value]).x + ImGui::GetStyle().FramePadding.x * 2;
+                    ImGui::SameLine(ImGui::GetContentRegionAvail().x - width);
+                    ImGui::Text("%s", label);
+                }
             }
         }
-
         PopStyleCombobox();
         ImGui::EndDisabled();
         ImGui::EndGroup();

--- a/soh/soh/SohGui/UIWidgets2.hpp
+++ b/soh/soh/SohGui/UIWidgets2.hpp
@@ -618,19 +618,21 @@ namespace UIWidgets2 {
         float comboWidth = CalcComboWidth(longest, options.flags);
 
         ImGui::AlignTextToFramePadding();
-        if (options.alignment == ComponentAlignment::Right) {
-            ImGui::Text("%s", label);
-            if (options.labelPosition == LabelPosition::Above) {
-                ImGui::NewLine();
-                ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
-            } else if (options.labelPosition == LabelPosition::Near) {
-                ImGui::SameLine();
-            } else if (options.labelPosition == LabelPosition::Far || options.labelPosition == LabelPosition::None) {
-                ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
-            }
-        } else if (options.alignment == ComponentAlignment::Left) {
-            if (options.labelPosition == LabelPosition::Above) {
+        if (options.labelPosition != LabelPosition::None) {
+            if (options.alignment == ComponentAlignment::Right) {
                 ImGui::Text("%s", label);
+                if (options.labelPosition == LabelPosition::Above) {
+                    ImGui::NewLine();
+                    ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
+                } else if (options.labelPosition == LabelPosition::Near) {
+                    ImGui::SameLine();
+                } else if (options.labelPosition == LabelPosition::Far || options.labelPosition == LabelPosition::None) {
+                    ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
+                }
+            } else if (options.alignment == ComponentAlignment::Left) {
+                if (options.labelPosition == LabelPosition::Above) {
+                    ImGui::Text("%s", label);
+                }
             }
         }
 
@@ -694,19 +696,21 @@ namespace UIWidgets2 {
         float comboWidth = CalcComboWidth(longest, options.flags);
 
         ImGui::AlignTextToFramePadding();
-        if (options.alignment == ComponentAlignment::Right) {
-            ImGui::Text("%s", label);
-            if (options.labelPosition == LabelPosition::Above) {
-                ImGui::NewLine();
-                ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
-            } else if (options.labelPosition == LabelPosition::Near) {
-                ImGui::SameLine();
-            } else if (options.labelPosition == LabelPosition::Far || options.labelPosition == LabelPosition::None) {
-                ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
-            }
-        } else if (options.alignment == ComponentAlignment::Left) {
-            if (options.labelPosition == LabelPosition::Above) {
+        if (options.labelPosition != LabelPosition::None) {
+            if (options.alignment == ComponentAlignment::Right) {
                 ImGui::Text("%s", label);
+                if (options.labelPosition == LabelPosition::Above) {
+                    ImGui::NewLine();
+                    ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
+                } else if (options.labelPosition == LabelPosition::Near) {
+                    ImGui::SameLine();
+                } else if (options.labelPosition == LabelPosition::Far || options.labelPosition == LabelPosition::None) {
+                    ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
+                }
+            } else if (options.alignment == ComponentAlignment::Left) {
+                if (options.labelPosition == LabelPosition::Above) {
+                    ImGui::Text("%s", label);
+                }
             }
         }
 
@@ -772,19 +776,21 @@ namespace UIWidgets2 {
         float comboWidth = CalcComboWidth(longest, options.flags);
 
         ImGui::AlignTextToFramePadding();
-        if (options.alignment == ComponentAlignment::Right) {
-            ImGui::Text("%s", label);
-            if (options.labelPosition == LabelPosition::Above) {
-                ImGui::NewLine();
-                ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
-            } else if (options.labelPosition == LabelPosition::Near) {
-                ImGui::SameLine();
-            } else if (options.labelPosition == LabelPosition::Far || options.labelPosition == LabelPosition::None) {
-                ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
-            }
-        } else if (options.alignment == ComponentAlignment::Left) {
-            if (options.labelPosition == LabelPosition::Above) {
+        if (options.labelPosition != LabelPosition::None) {
+            if (options.alignment == ComponentAlignment::Right) {
                 ImGui::Text("%s", label);
+                if (options.labelPosition == LabelPosition::Above) {
+                    ImGui::NewLine();
+                    ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
+                } else if (options.labelPosition == LabelPosition::Near) {
+                    ImGui::SameLine();
+                } else if (options.labelPosition == LabelPosition::Far || options.labelPosition == LabelPosition::None) {
+                    ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
+                }
+            } else if (options.alignment == ComponentAlignment::Left) {
+                if (options.labelPosition == LabelPosition::Above) {
+                    ImGui::Text("%s", label);
+                }
             }
         }
 
@@ -853,19 +859,21 @@ namespace UIWidgets2 {
         float comboWidth = CalcComboWidth(longest, options.flags);
 
         ImGui::AlignTextToFramePadding();
-        if (options.alignment == ComponentAlignment::Right) {
-            ImGui::Text("%s", label);
-            if (options.labelPosition == LabelPosition::Above) {
-                ImGui::NewLine();
-                ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
-            } else if (options.labelPosition == LabelPosition::Near) {
-                ImGui::SameLine();
-            } else if (options.labelPosition == LabelPosition::Far || options.labelPosition == LabelPosition::None) {
-                ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
-            }
-        } else if (options.alignment == ComponentAlignment::Left) {
-            if (options.labelPosition == LabelPosition::Above) {
+        if (options.labelPosition != LabelPosition::None) {
+            if (options.alignment == ComponentAlignment::Right) {
                 ImGui::Text("%s", label);
+                if (options.labelPosition == LabelPosition::Above) {
+                    ImGui::NewLine();
+                    ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
+                } else if (options.labelPosition == LabelPosition::Near) {
+                    ImGui::SameLine();
+                } else if (options.labelPosition == LabelPosition::Far || options.labelPosition == LabelPosition::None) {
+                    ImGui::SameLine(ImGui::GetContentRegionAvail().x - comboWidth);
+                }
+            } else if (options.alignment == ComponentAlignment::Left) {
+                if (options.labelPosition == LabelPosition::Above) {
+                    ImGui::Text("%s", label);
+                }
             }
         }
 


### PR DESCRIPTION
Before, if you set Combobox LabelPosition::None, it would do the same thing as LabelPosition::Far. Fixed that and also fixed the Slider Width calculation for LabelPositions other than LabelPosition::Above

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/Malkierian/Shipwright/actions/artifacts/2733674838.zip)
  - [soh-mac.zip](https://nightly.link/Malkierian/Shipwright/actions/artifacts/2733681290.zip)
  - [soh-windows.zip](https://nightly.link/Malkierian/Shipwright/actions/artifacts/2733688269.zip)
<!--- section:artifacts:end -->