### PR TITLE
Block Syncing Items and Flags when playing Archi

### DIFF
--- a/soh/soh/Network/Anchor/Menu.cpp
+++ b/soh/soh/Network/Anchor/Menu.cpp
@@ -126,12 +126,18 @@ void AnchorMainMenu(WidgetInfo& info) {
     ImGui::SeparatorText("Current Room");
     ImGui::Text("%s Connected", ICON_FA_CHECK);
 
+    if (IS_ARCHIPELAGO)
+        ImGui::BeginDisabled();
+
     UIWidgets::PushStyleButton(THEME_COLOR);
     if (ImGui::Button("Request Team State")) {
         anchor->SendPacket_RequestTeamState();
     }
     UIWidgets::Tooltip("Try this if you are missing items or flags that your team members have collected");
     UIWidgets::PopStyleButton();
+
+    if (IS_ARCHIPELAGO)
+        ImGui::EndDisabled();
 
     ImGui::SameLine();
 
@@ -186,9 +192,19 @@ void AnchorAdminMenu(WidgetInfo& info) {
                                     .Color(THEME_COLOR))) {
         anchor->SendPacket_UpdateRoomState();
     }
+
+    if (IS_ARCHIPELAGO) {
+        CVarSetInteger(CVAR_REMOTE_ANCHOR("RoomSettings.SyncItemsAndFlags"), 0);
+        ImGui::BeginDisabled();
+    }
+
     if (UIWidgets::CVarCheckbox("Sync Items & Flags", CVAR_REMOTE_ANCHOR("RoomSettings.SyncItemsAndFlags"),
                                 UIWidgets::CheckboxOptions().DefaultValue(true).Color(THEME_COLOR))) {
         anchor->SendPacket_UpdateRoomState();
+    }
+
+    if (IS_ARCHIPELAGO) {
+        ImGui::EndDisabled();
     }
 }
 

--- a/soh/soh/Network/Archipelago/Archipelago.cpp
+++ b/soh/soh/Network/Archipelago/Archipelago.cpp
@@ -48,6 +48,8 @@ bool ArchipelagoClient::StartClient() {
         apClient.reset();
     }
 
+    CVarSetInteger(CVAR_REMOTE_ANCHOR("RoomSettings.SyncItemsAndFlags"), 0);
+
     disconnecting = false;
     retries = 0;
     uri = CVarGetString(CVAR_REMOTE_ARCHIPELAGO("ServerAddress"), "localhost:38281");


### PR DESCRIPTION
If you sync items and flags in an Archi save it can mess up your save. This is what I did in my Anchorpelago branch to prevent that from happening. Figured I'd share it here. Might be better ways to do it though, but this was my quick and easy fix for it.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/Malkierian/Shipwright/actions/artifacts/4714159739.zip)
  - [soh-windows.zip](https://nightly.link/Malkierian/Shipwright/actions/artifacts/4714174405.zip)
  - [soh-mac.zip](https://nightly.link/Malkierian/Shipwright/actions/artifacts/4718312346.zip)
<!--- section:artifacts:end -->