### PR TITLE
Seems to fix the cvar registrations

### DIFF
--- a/soh/soh/Enhancements/Holiday/AGreenSpoon.cpp
+++ b/soh/soh/Enhancements/Holiday/AGreenSpoon.cpp
@@ -69,5 +69,5 @@ static void RegisterMenu() {
         .Options(UIWidgets::CheckboxOptions().Tooltip("Don't you dare talk to them."));
 }
 
-static RegisterShipInitFunc initFunc(OnConfigurationChanged);
+static RegisterShipInitFunc initFunc(OnConfigurationChanged, { CVAR("EvilGossipStone") });
 static RegisterMenuInitFunc menuInitFunc(RegisterMenu);

--- a/soh/soh/Enhancements/Holiday/Archez.cpp
+++ b/soh/soh/Enhancements/Holiday/Archez.cpp
@@ -117,5 +117,5 @@ static void RegisterMenu() {
             "Overrides most charactor skeletons with snow balls to make them look like Snow Golems"));
 }
 
-static RegisterShipInitFunc initFunc(OnConfigurationChanged);
+static RegisterShipInitFunc initFunc(OnConfigurationChanged, { CVAR("SnowGolems") });
 static RegisterMenuInitFunc menuInitFunc(RegisterMenu);

--- a/soh/soh/Enhancements/Holiday/Fredomato.cpp
+++ b/soh/soh/Enhancements/Holiday/Fredomato.cpp
@@ -525,5 +525,8 @@ static void RegisterMenu() {
         .Options(UIWidgets::IntSliderOptions().DefaultValue(1000).Min(40).Max(2000));
 }
 
-static RegisterShipInitFunc initFunc(OnConfigurationChanged);
+static RegisterShipInitFunc initFunc(OnConfigurationChanged, {
+                                                                 CVAR("FredsQuest.Enabled"),
+                                                                 CVAR("RandomTraps.Enabled"),
+                                                             });
 static RegisterMenuInitFunc menuInitFunc(RegisterMenu);

--- a/soh/soh/Enhancements/Holiday/Grimey.cpp
+++ b/soh/soh/Enhancements/Holiday/Grimey.cpp
@@ -221,5 +221,8 @@ static void RegisterMenu() {
         .Options(UIWidgets::CheckboxOptions().Tooltip("Ever persistent hailstorm throughout hyrule"));
 }
 
-static RegisterShipInitFunc initFunc(OnConfigurationChanged);
+static RegisterShipInitFunc initFunc(OnConfigurationChanged, {
+                                                                 CVAR("Penguins"),
+                                                                 CVAR("Hailstorm"),
+                                                             });
 static RegisterMenuInitFunc menuInitFunc(RegisterMenu);

--- a/soh/soh/Enhancements/Holiday/NotProxySaw.cpp
+++ b/soh/soh/Enhancements/Holiday/NotProxySaw.cpp
@@ -131,5 +131,5 @@ static void RegisterMenu() {
                                                       "attempt to convince Ganon to join you instead."));
 }
 
-static RegisterShipInitFunc initFunc(OnConfigurationChanged);
+static RegisterShipInitFunc initFunc(OnConfigurationChanged, { CVAR("GanonDatingSim") });
 static RegisterMenuInitFunc menuInitFunc(RegisterMenu);

--- a/soh/soh/Enhancements/Holiday/ProxySaw.cpp
+++ b/soh/soh/Enhancements/Holiday/ProxySaw.cpp
@@ -222,5 +222,6 @@ static void RegisterMenu() {
     SohGui::mSohMenu->AddWidget(path, "Super Bonk", WIDGET_CVAR_CHECKBOX).CVar(CVAR("SuperBonk"));
 }
 
-static RegisterShipInitFunc initFunc(OnConfigurationChanged);
+static RegisterShipInitFunc initFunc(OnConfigurationChanged, { CVAR("Snowballs"), CVAR("Icebergs"),
+                                                               CVAR("DownTheRabbitHole"), CVAR("SuperBonk") });
 static RegisterMenuInitFunc menuInitFunc(RegisterMenu);

--- a/soh/soh/Enhancements/Holiday/aMannus.cpp
+++ b/soh/soh/Enhancements/Holiday/aMannus.cpp
@@ -68,5 +68,5 @@ static void RegisterMenu() {
             "Using Nayru's Love will now act as Roc's Feather instead! No magic required."));
 }
 
-static RegisterShipInitFunc initFunc(OnConfigurationChanged);
+static RegisterShipInitFunc initFunc(OnConfigurationChanged, { CVAR("RocsFeather") });
 static RegisterMenuInitFunc menuInitFunc(RegisterMenu);

--- a/soh/soh/Enhancements/Holiday/lilDavid.cpp
+++ b/soh/soh/Enhancements/Holiday/lilDavid.cpp
@@ -123,5 +123,5 @@ static void RegisterMenu() {
         .Options(UIWidgets::CheckboxOptions().Tooltip("Equip bombs over an already equipped Bow to shoot bomb arrows"));
 }
 
-static RegisterShipInitFunc initFunc(OnConfigurationChanged);
+static RegisterShipInitFunc initFunc(OnConfigurationChanged, { CVAR("BombArrows.Enabled") });
 static RegisterMenuInitFunc menuInitFunc(RegisterMenu);


### PR DESCRIPTION
Cvars seemed to only register when the game loaded, so this makes it so they register every time the cvar is changed.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/Malkierian/Shipwright/actions/artifacts/4717769649.zip)
  - [soh-windows.zip](https://nightly.link/Malkierian/Shipwright/actions/artifacts/4717790429.zip)
  - [soh-mac.zip](https://nightly.link/Malkierian/Shipwright/actions/artifacts/4718265374.zip)
<!--- section:artifacts:end -->