### PR TITLE
Make Extra Traps fully random when in Archi save file

### DIFF
--- a/soh/soh/Enhancements/ExtraTraps.cpp
+++ b/soh/soh/Enhancements/ExtraTraps.cpp
@@ -63,6 +63,10 @@ std::vector<AltTrapType> getEnabledAddTraps() {
 static void RollRandomTrap(uint32_t seed) {
     uint32_t finalSeed = seed + (IS_RANDO ? Rando::Context::GetInstance()->GetSeed()
                                           : static_cast<uint32_t>(gSaveContext.ship.stats.fileCreatedAt));
+    // Makes Extra Traps completely random in Archipelago since GI is always the same
+    if (IS_ARCHIPELAGO) {
+        finalSeed += rand();
+    }
     Random_Init(finalSeed);
 
     roll = RandomElement(getEnabledAddTraps());


### PR DESCRIPTION
Since extra traps are based off GI model ID and Scene ID and the GI model is always a gold rupee (Or I guess in this case it's the coal, but same result) in Multiworld Archi, it would always be the same trap per scene. This just makes them fully random so you don't keep getting the same ones and leaves it normal for regular Rando.

<!--- section:artifacts:start -->
### Build Artifacts
  - [soh-linux.zip](https://nightly.link/Malkierian/Shipwright/actions/artifacts/4788516912.zip)
  - [soh-windows.zip](https://nightly.link/Malkierian/Shipwright/actions/artifacts/4788554326.zip)
  - [soh-mac.zip](https://nightly.link/Malkierian/Shipwright/actions/artifacts/4788719092.zip)
<!--- section:artifacts:end -->